### PR TITLE
Establish project-wide contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,9 @@ We use GitHub Issues for a wide range of tasks including bug reports, feature re
 
 ## Pull Requests
 
-Project Cognoma operates on a pull request model. All changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). Component projects (e.g. `cognoma/django-cognoma`) may define their own pull request models to facilitate emergency fixes if required.
- We also encourage you to comment on and review open pull requests.
+Project Cognoma operates on a pull request model. All changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). Component projects (e.g. `cognoma/django-cognoma`) may define their own pull request models to facilitate emergency fixes if required. We also encourage you to comment on and review open pull requests.
 
 To keep the commit history clean, we may ask you to [rebase your pull request](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request "How to Rebase a Pull Request") or squash certain commits. If you don't know what this means, we'll help you through the process.
-
 
 **Happy Contributing!**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ We use GitHub Issues for a wide range of tasks including bug reports, feature re
 
 ## Pull Requests
 
-Project Cognoma operates on a pull request model. Substantial changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). We also encourage you to comment on and review open pull requests.
+Project Cognoma operates on a pull request model. All changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). Component projects (e.g. `cognoma/django-cognoma`) may define their own pull request models to facilitate emergency fixes if required.
+ We also encourage you to comment on and review open pull requests.
 
 To keep the commit history clean, we may ask you to [rebase your pull request](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request "How to Rebase a Pull Request") or squash certain commits. If you don't know what this means, we'll help you through the process.
+
 
 **Happy Contributing!**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to a Project Cognoma Repository
+# Contribution guidelines for Project Cognoma repositories
 
 ## Project Philosophy
 
@@ -10,11 +10,11 @@ We use GitHub Issues for a wide range of tasks including bug reports, feature re
 
 ## Pull Requests
 
-Project Cognoma operates on a pull request model. All changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). Component projects (e.g. `cognoma/django-cognoma`) may define their own pull request models to facilitate emergency fixes if required. We also encourage you to comment on and review open pull requests.
+Project Cognoma operates on a pull request model. For the `cognoma/cognoma` repository, all changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). Component projects (e.g. `cognoma/django-cognoma`) may define their own pull request models to facilitate emergency fixes if required. We also encourage you to comment on and review open pull requests.
 
 To keep the commit history clean, we may ask you to [rebase your pull request](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request "How to Rebase a Pull Request") or squash certain commits. If you don't know what this means, we'll help you through the process.
 
-**Happy Contributing!**
+**Happy contributing!**
 
 ***
 
@@ -22,9 +22,6 @@ _Note: You do not have to read the following information to contribute._
 
 ## Commit Access
 
-Currently, [members](https://github.com/orgs/cognoma/people "Cognoma People") of the `cognoma` GitHub organization have commit access on all [cognoma repositories](https://github.com/cognoma). However, our goal is to transition to sustainable project development without the direct need for organization involvement. Therefore, organization members will grant (and revoke) commit access on a per repository level. For example, a Django developer working on [`cognoma/django-cognoma`](https://github.com/cognoma/django-cognoma) will receive commit access to `cognoma/django-cognoma` but not necessarily `cognoma/cognoma`. Commit access will be extended based on a history of positive involvement in the project. Commit access should be used for two purposes:
+Currently, [members](https://github.com/orgs/cognoma/people "Cognoma People") of the `cognoma` GitHub organization have commit access on all [cognoma repositories](https://github.com/cognoma). However, our goal is to transition to sustainable project development without the direct need for organization involvement. Therefore, organization members will grant (and revoke) commit access on a per repository level. For example, a Django developer working on [`cognoma/django-cognoma`](https://github.com/cognoma/django-cognoma) will receive commit access to `cognoma/django-cognoma` but not necessarily `cognoma/cognoma`. Commit access will be extended based on a history of positive involvement in the project.
 
-1. Small or urgent changes where discussion or code review does not make sense.
-2. Merging pull requests that have undergone review. The committer should use their best judgment on how how much review is necessary for a given pull request. For some pull requests, a single individual with commit access may be able to fully review a pull request.
-
-If you think Project Cognoma would benefit from granting you commit access, please contact an [organization member](https://github.com/orgs/cognoma/people "Cognoma People"). However, please don't request commit access until you've accumulated a history of involvement in the project.
+The primary purpose of commit access is for merging pull requests. The committer should use their best judgment on how how much review is necessary for a given pull request. For some pull requests, a single individual with commit access may be able to fully review a pull request. Commit access may also be used for small or urgent changes as specified by the repository-specific `CONTRIBUTING.md`. If you think Project Cognoma would benefit from granting you commit access, please contact an [organization member](https://github.com/orgs/cognoma/people "Cognoma People"). However, please don't request commit access until you've accumulated a history of involvement in the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to a Project Cognoma Repository
+
+## Project Philosophy
+
+Project Cognoma is an open source community-based project. Beyond our immediate scientific aspirations, we want to engage as many individuals as possible in doing cool work. Project Cognoma is a place to learn and grow as a community. So don't be shy. We want your contribution. Given the nature of open source development, not all contributions can be included … but all will be appreciated and help the project bloom.
+
+## Issues
+
+We use GitHub Issues for a wide range of tasks including bug reports, feature requests, planning, and general forum. Don't worry about whether your use of GitHub Issues is legitimate, but do try to pick the best [repository](https://github.com/cognoma "Repositories of the Cognoma Organization") to file your issue under.
+
+## Pull Requests
+
+Project Cognoma operates on a pull request model. Substantial changes should be submitted via [pull request](https://help.github.com/articles/using-pull-requests/ "GitHub · Using pull requests"). We also encourage you to comment on and review open pull requests.
+
+To keep the commit history clean, we may ask you to [rebase your pull request](https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request "How to Rebase a Pull Request") or squash certain commits. If you don't know what this means, we'll help you through the process.
+
+**Happy Contributing!**
+
+***
+
+_Note: You do not have to read the following information to contribute._
+
+## Commit Access
+
+Currently, [members](https://github.com/orgs/cognoma/people "Cognoma People") of the `cognoma` GitHub organization have commit access on all [cognoma repositories](https://github.com/cognoma). However, our goal is to transition to sustainable project development without the direct need for organization involvement. Therefore, organization members will grant (and revoke) commit access on a per repository level. For example, a Django developer working on [`cognoma/django-cognoma`](https://github.com/cognoma/django-cognoma) will receive commit access to `cognoma/django-cognoma` but not necessarily `cognoma/cognoma`. Commit access will be extended based on a history of positive involvement in the project. Commit access should be used for two purposes:
+
+1. Small or urgent changes where discussion or code review does not make sense.
+2. Merging pull requests that have undergone review. The committer should use their best judgment on how how much review is necessary for a given pull request. For some pull requests, a single individual with commit access may be able to fully review a pull request.
+
+If you think Project Cognoma would benefit from granting you commit access, please contact an [organization member](https://github.com/orgs/cognoma/people "Cognoma People"). However, please don't request commit access until you've accumulated a history of involvement in the project.


### PR DESCRIPTION
`CONTRIBUTING.md` provides high-level guidelines for contributing to Project Cognoma repositories.

Specific respositories, such as [`django-cognoma`](https://github.com/cognoma/django-cognoma) may want to add their own `CONTRIBUTING.md` files that link to these guidelines and then contain repo-specific guidelines.

I'm looking for feedback before merging these guidelines.
